### PR TITLE
Set installability analysis workflow (WIP)

### DIFF
--- a/.github/workflows/installability.yml
+++ b/.github/workflows/installability.yml
@@ -1,0 +1,37 @@
+name: Plugins
+
+on:
+  schedule:
+    # Every Monday and Thursday, at 6am
+    - "0 6 * * 1,4"
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  packages:
+    name: Installability
+    runs-on: ubuntu-latest
+    if: startsWith(github.repository, 'napari')
+    strategy:
+      fail-fast: false
+      matrix:
+        subdir:
+          - "linux-64"
+          - "osx-64"
+          - "osx-arm64"
+          - "win-64"
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: environments/installability.yml
+      - name: Run script
+        shell: bash -el {0}
+        env:
+          CONDA_SUBDIR: ${{ matrix.subdir }}
+        run: python ci_scripts/check_installability_plugins.py
+

--- a/.github/workflows/installability.yml
+++ b/.github/workflows/installability.yml
@@ -3,7 +3,7 @@ name: Plugins
 on:
   schedule:
     # Every Monday and Thursday, at 6am
-    - "0 6 * * 1,4"
+    - cron: "0 6 * * 1,4"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/installability.yml
+++ b/.github/workflows/installability.yml
@@ -33,11 +33,15 @@ jobs:
       - uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: environments/installability.yml
-          extra-specs: |
-            python=${{ matrix.python-version }}
-      - name: Run script
+      - name: Check installability one by one
         shell: bash -el {0}
         env:
           CONDA_SUBDIR: ${{ matrix.subdir }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
         run: python ci_scripts/check_installability_plugins.py
-
+      - name: Check installability of all plugins at once
+        shell: bash -el {0}
+        env:
+          CONDA_SUBDIR: ${{ matrix.subdir }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: python ci_scripts/check_installability_plugins.py --all

--- a/.github/workflows/installability.yml
+++ b/.github/workflows/installability.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   packages:
-    name: Installability
+    name: Installability, ${{ matrix.subdir }}, Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     if: startsWith(github.repository, 'napari')
     strategy:
@@ -23,12 +23,18 @@ jobs:
           - "osx-64"
           - "osx-arm64"
           - "win-64"
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
 
     steps:
       - uses: actions/checkout@v2
       - uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: environments/installability.yml
+          extra-specs: |
+            python=${{ matrix.python-version }}
       - name: Run script
         shell: bash -el {0}
         env:

--- a/.github/workflows/installability.yml
+++ b/.github/workflows/installability.yml
@@ -41,6 +41,7 @@ jobs:
         run: python ci_scripts/check_installability_plugins.py
       - name: Check installability of all plugins at once
         shell: bash -el {0}
+        if: always()
         env:
           CONDA_SUBDIR: ${{ matrix.subdir }}
           PYTHON_VERSION: ${{ matrix.python-version }}

--- a/ci_scripts/check_installability_plugins.py
+++ b/ci_scripts/check_installability_plugins.py
@@ -116,7 +116,7 @@ def main():
     names_to_check = {"napari"}
     plugin_specs = []
     print("Preparing tasks...")
-    for i, (pypi_name, conda_name) in enumerate(plugin_names.items()):
+    for pypi_name, conda_name in plugin_names.items():
         if conda_name is not None:
             plugin_spec = conda_name.replace("/", "::")
             if not args.all:
@@ -125,8 +125,6 @@ def main():
                     plugin_spec += f"=={latest_version}"
             plugin_specs.append(plugin_spec)
             names_to_check.add(conda_name.split("/")[1])
-        if i > 9:
-            break
 
     if args.all:
         tasks = [(python_spec, napari_spec, *plugin_specs)]

--- a/ci_scripts/check_installability_plugins.py
+++ b/ci_scripts/check_installability_plugins.py
@@ -110,7 +110,7 @@ def main():
     pyver = os.environ.get(
         "PYTHON_VERSION", f"{sys.version_info.major}.{sys.version_info.minor}"
     )
-    python_spec = f"python={pyver}=*cpython"
+    python_spec = f"python={pyver}.*=*cpython"
     napari_spec = f"napari={_latest_napari_on_conda_forge()}=*pyside*"
     plugin_names = _all_plugin_names()
     plugin_specs = []

--- a/ci_scripts/check_installability_plugins.py
+++ b/ci_scripts/check_installability_plugins.py
@@ -2,78 +2,138 @@
 
 """
 Check if all Hub-listed plugins can be installed together with latest napari
+
+Environment variables that affect the script:
+
+- CONDA_SUBDIR: Platform to do checks against (linux-64, osx-64, etc)
+- PYTHON_VERSION: Which Python version we are testing against
 """
 
+from argparse import ArgumentParser
+from collections import defaultdict
+from functools import lru_cache
+from subprocess import run, PIPE
 import json
-from subprocess import CalledProcessError, check_output, STDOUT
+import os
+import sys
+import time
 
+from tqdm import tqdm
+from conda.models.version import VersionOrder
 import requests
 
 NPE2API_CONDA = "https://npe2api.vercel.app/api/conda"
 
 
-def check_output_verbose(*args, **kwargs):
-    """
-    Check return code of a subprocess, capturing stdout and stderr.
-    If an error happened, print both streams, then raise.
-    """
-    kwargs.pop("stderr", None)
-    kwargs.pop("text", None)
-    kwargs.pop("universal_newlines", None)
-    try:
-        return check_output(*args, stderr=STDOUT, text=True, **kwargs)
-    except CalledProcessError as exc:
-        print("Output:")
-        print(exc.stdout)
-        raise
-
-
+@lru_cache
 def latest_napari_on_conda_forge():
     r = requests.get("https://api.anaconda.org/package/conda-forge/napari")
     r.raise_for_status()
     return r.json()["latest_version"]
 
 
+@lru_cache
 def all_plugin_names():
     r = requests.get(NPE2API_CONDA)
     r.raise_for_status()
     return r.json()
 
 
-def is_latest_version(name, version):
+@lru_cache
+def latest_version(name):
     r = requests.get(f"{NPE2API_CONDA}/{name}")
     r.raise_for_status()
-    latest_version = r.json()["latest_version"]
-    return version >= latest_version
+    time.sleep(0.1)
+    return r.json()["latest_version"]
 
 
-def solve(specs):
-    resp = check_output_verbose(
-        [
-            "micromamba",
-            "create",
-            "-n",
-            "notused",
-            "--dry-run",
-            "-c",
-            "conda-forge",
-            "--json",
-            *specs,
-        ]
-    )
-    print(resp)
-    return json.loads(resp)
+@lru_cache
+def patched_environment():
+    platform = os.environ.get("CONDA_SUBDIR")
+    if not platform:
+        return
+    env = os.environ.copy()
+    if platform.startswith("linux-"):
+        env.setdefault("CONDA_OVERRIDE_GLIBC", "2.17")
+        env.setdefault("CONDA_OVERRIDE_CUDA", "11.2")
+    elif platform.startswith("osx-"):
+        env.setdefault("CONDA_OVERRIDE_OSX", "11.2")
+    return env
+
+
+def solve(*args):
+    command = [
+        "micromamba",
+        "create",
+        "-n",
+        "notused",
+        "--dry-run",
+        "-c",
+        "conda-forge",
+        "--json",
+        *args,
+    ]
+    resp = run(command, stdout=PIPE, stderr=PIPE, text=True, env=patched_environment())
+    try:
+        return json.loads(resp.stdout)
+    except json.JSONDecodeError:
+        print("Command:", command)
+        print("Output:", resp.stdout)
+        raise
+
+
+def cli():
+    p = ArgumentParser()
+    p.add_argument("--all", action="store_true")
+    return p.parse_args()
 
 
 def main():
-    specs = [f"napari={latest_napari_on_conda_forge()}"]
+    pyver = os.environ.get(
+        "PYTHON_VERSION", f"{sys.version_info.major}.{sys.version_info.minor}"
+    )
+    python_spec = f"python={pyver}"
+    napari_spec = f"napari={latest_napari_on_conda_forge()}"
     plugin_names = all_plugin_names()
+    plugin_specs = []
     for _, conda_name in plugin_names.items():
         if conda_name is not None:
-            specs.append(conda_name.replace("/", "::"))
+            plugin_specs.append(conda_name.replace("/", "::"))
 
-    result = solve(specs)
+    args = cli()
+    if args.all:
+        tasks = [(python_spec, napari_spec, *plugin_specs)]
+    else:
+        tasks = [
+            (python_spec, napari_spec, plugin_spec) for plugin_spec in plugin_specs[:10]
+        ]
+
+    failures = defaultdict(list)
+    n_tasks = len(tasks)
+    for i, task in enumerate(tasks, 1):
+        print(f"Task {i:4d}/{n_tasks}:", *task)
+        result = solve(*task)
+        if result["success"] is True:
+            for pkg in result["actions"]["LINK"]:
+                if pkg["name"] in plugin_names:
+                    pkg_latest_version = latest_version(pkg["name"])
+                    if VersionOrder(pkg["version"]) < VersionOrder(pkg_latest_version):
+                        failures[task].append(
+                            f'{pkg["name"]}=={pkg["version"]} '
+                            f"is not the latest version ({pkg_latest_version})"
+                        )
+        else:
+            failures[task].extend(result["solver_problems"])
+    print("-" * 20)
+    for task, failure_list in failures.items():
+        print("Installation attempt for", *task, "did not succeed!")
+        print("Reasons:")
+        for failure in failure_list:
+            print(" - ", failure)
+        print("-" * 20)
+
+    return len(failures)
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/ci_scripts/check_installability_plugins.py
+++ b/ci_scripts/check_installability_plugins.py
@@ -105,7 +105,7 @@ def main():
         tasks = [(python_spec, napari_spec, *plugin_specs)]
     else:
         tasks = [
-            (python_spec, napari_spec, plugin_spec) for plugin_spec in plugin_specs[:10]
+            (python_spec, napari_spec, plugin_spec) for plugin_spec in plugin_specs
         ]
 
     failures = defaultdict(list)

--- a/ci_scripts/check_installability_plugins.py
+++ b/ci_scripts/check_installability_plugins.py
@@ -54,10 +54,13 @@ def patched_environment():
         return
     env = os.environ.copy()
     if platform.startswith("linux-"):
+        env.setdefault("CONDA_OVERRIDE_LINUX", "1")
         env.setdefault("CONDA_OVERRIDE_GLIBC", "2.17")
         env.setdefault("CONDA_OVERRIDE_CUDA", "11.2")
     elif platform.startswith("osx-"):
         env.setdefault("CONDA_OVERRIDE_OSX", "11.2")
+    elif platform.startswith("win-"):
+        env.setdefault("CONDA_OVERRIDE_WIN", "1")
     return env
 
 

--- a/ci_scripts/check_installability_plugins.py
+++ b/ci_scripts/check_installability_plugins.py
@@ -169,8 +169,12 @@ def main():
         for failure in failure_list:
             print(" - ", failure)
         print("-" * 20)
-
-    return len(failures)
+    if args.all:
+        # single task, the exit code is the number of problems
+        return sum(len(problems) for problems in failures.values())
+    else:
+        # several tasks, the exit code is the number of tasks that failed
+        return len(failures)
 
 
 if __name__ == "__main__":

--- a/ci_scripts/check_installability_plugins.py
+++ b/ci_scripts/check_installability_plugins.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+"""
+Check if all Hub-listed plugins can be installed together with latest napari
+"""
+
+import json
+from subprocess import CalledProcessError, check_output, STDOUT
+
+import requests
+
+NPE2API_CONDA = "https://npe2api.vercel.app/api/conda"
+
+
+def check_output_verbose(*args, **kwargs):
+    """
+    Check return code of a subprocess, capturing stdout and stderr.
+    If an error happened, print both streams, then raise.
+    """
+    kwargs.pop("stderr", None)
+    kwargs.pop("text", None)
+    kwargs.pop("universal_newlines", None)
+    try:
+        return check_output(*args, stderr=STDOUT, text=True, **kwargs)
+    except CalledProcessError as exc:
+        print("Output:")
+        print(exc.stdout)
+        raise
+
+
+def latest_napari_on_conda_forge():
+    r = requests.get("https://api.anaconda.org/package/conda-forge/napari")
+    r.raise_for_status()
+    return r.json()["latest_version"]
+
+
+def all_plugin_names():
+    r = requests.get(NPE2API_CONDA)
+    r.raise_for_status()
+    return r.json()
+
+
+def is_latest_version(name, version):
+    r = requests.get(f"{NPE2API_CONDA}/{name}")
+    r.raise_for_status()
+    latest_version = r.json()["latest_version"]
+    return version >= latest_version
+
+
+def solve(specs):
+    resp = check_output_verbose(
+        [
+            "micromamba",
+            "create",
+            "-n",
+            "notused",
+            "--dry-run",
+            "-c",
+            "conda-forge",
+            "--json",
+            *specs,
+        ]
+    )
+    print(resp)
+    return json.loads(resp)
+
+
+def main():
+    specs = [f"napari={latest_napari_on_conda_forge()}"]
+    plugin_names = all_plugin_names()
+    for _, conda_name in plugin_names.items():
+        if conda_name is not None:
+            specs.append(conda_name.replace("/", "::"))
+
+    result = solve(specs)

--- a/ci_scripts/check_installability_plugins.py
+++ b/ci_scripts/check_installability_plugins.py
@@ -93,7 +93,7 @@ def main():
         "PYTHON_VERSION", f"{sys.version_info.major}.{sys.version_info.minor}"
     )
     python_spec = f"python={pyver}"
-    napari_spec = f"napari={latest_napari_on_conda_forge()}"
+    napari_spec = f"napari={latest_napari_on_conda_forge()}=*pyside*"
     plugin_names = all_plugin_names()
     plugin_specs = []
     for _, conda_name in plugin_names.items():
@@ -122,11 +122,15 @@ def main():
                             f'{pkg["name"]}=={pkg["version"]} '
                             f"is not the latest version ({pkg_latest_version})"
                         )
+                elif pkg["name"].lower().startswith("pyqt"):
+                    failures[task].append(
+                        f"Solution includes {pkg['name']}=={pkg['version']}"
+                    )
         else:
             failures[task].extend(result["solver_problems"])
     print("-" * 20)
     for task, failure_list in failures.items():
-        print("Installation attempt for", *task, "did not succeed!")
+        print("Installation attempt for", *task, "has errors!")
         print("Reasons:")
         for failure in failure_list:
             print(" - ", failure)

--- a/ci_scripts/check_installability_plugins.py
+++ b/ci_scripts/check_installability_plugins.py
@@ -130,7 +130,7 @@ def main():
 
     failures = defaultdict(list)
     n_tasks = len(tasks)
-    names_to_check = {"napari", *plugin_names}
+    names_to_check = {"napari", *[name.lower() for name in plugin_names]}
     for i, task in enumerate(tasks, 1):
         print(f"Task {i:4d}/{n_tasks}:", *task)
         result = _solve(*task)
@@ -139,15 +139,17 @@ def main():
             # it doesn't mean it's a valid one because metadata
             # can have errors!
             for pkg in result["actions"]["LINK"]:
-                if pkg["name"] in names_to_check:
+                pkg_name_lower = pkg["name"].lower()
+                if pkg_name_lower in names_to_check:
                     # 1) We should have obtained the latest version
                     #    of the plugin. If not, metadata is faulty!
                     maybe_failures = _check_if_latest(pkg)
                     if maybe_failures:
                         failures[task].extend(maybe_failures)
-                elif pkg["name"].lower().startswith("pyqt"):
+                elif pkg_name_lower.startswith("pyqt") and pkg_name_lower != "pyqtgraph":
                     # 2) We want pyside only. If pyqt lands in the env
                     #    it was pulled by the plugin or its dependencies.
+                    #    Note that pyqtgraph, despite the name, can use pyside too.
                     failures[task].append(
                         f"Solution includes {pkg['name']}=={pkg['version']}"
                     )

--- a/ci_scripts/check_installability_plugins.py
+++ b/ci_scripts/check_installability_plugins.py
@@ -110,7 +110,7 @@ def main():
     pyver = os.environ.get(
         "PYTHON_VERSION", f"{sys.version_info.major}.{sys.version_info.minor}"
     )
-    python_spec = f"python={pyver}"
+    python_spec = f"python={pyver}=*cpython"
     napari_spec = f"napari={_latest_napari_on_conda_forge()}=*pyside*"
     plugin_names = _all_plugin_names()
     plugin_specs = []

--- a/ci_scripts/check_installability_plugins.py
+++ b/ci_scripts/check_installability_plugins.py
@@ -73,3 +73,7 @@ def main():
             specs.append(conda_name.replace("/", "::"))
 
     result = solve(specs)
+
+
+if __name__ == "__main__":
+    main()

--- a/environments/installability.yml
+++ b/environments/installability.yml
@@ -1,0 +1,7 @@
+name: installability
+channels:
+  - conda-forge
+dependencies:
+  - conda
+  - mamba
+  - python

--- a/environments/installability.yml
+++ b/environments/installability.yml
@@ -2,6 +2,5 @@ name: installability
 channels:
   - conda-forge
 dependencies:
+  - python=3.9
   - conda
-  - mamba
-  - python


### PR DESCRIPTION
We are testing for:

* Creating an environment with Python, latest napari for pyside and all plugins _at once_
* Same, but one environment per plugin. They all should be individually installable in at least one platform.
* The matrix covers four platforms (Linux and Windows x64, plus macOS Intel/M1), and Python 3.8, 3.9 and 3.10.
* The exit codes for each task reflect the number of problems. These can be seen from the Summary page of each run, and do not expire :D Useful to track how rough the landscape is over time.

The time spent in each combination is super interesting, which gives you an idea on how different the packaging landscapes are across platforms!