### PR TITLE
Discard extra info in versions strings

### DIFF
--- a/build_installers.py
+++ b/build_installers.py
@@ -104,7 +104,7 @@ def _version():
             # we just want the version tag, number of commits after tag,
             # and git hash;  so we discard the date
             pre, post = version.split("+", 1)
-            version = f"{pre}_{post.split('.')[0]}"
+            version = f"{pre}+{post.split('.')[0]}"
             return version
     else:
         # get latest published on conda-forge

--- a/build_installers.py
+++ b/build_installers.py
@@ -98,8 +98,14 @@ def _use_local():
 def _version():
     if _use_local():
         version = importlib.metadata.version("napari")
-        if "+" in version:  # discard git hash and date
-            return version.split("+")[0]
+        if "+" in version:
+            # a version string can be something like:
+            # 0.4.16rc2.dev252+gf6bdd623.d20220827
+            # we just want the version tag, number of commits after tag,
+            # and git hash;  so we discard the date
+            pre, post = version.split("+", 1)
+            version = f"{pre}_{post.split('.')[0]}"
+            return version
     else:
         # get latest published on conda-forge
         r = requests.get(f"https://api.anaconda.org/package/conda-forge/napari")

--- a/build_installers.py
+++ b/build_installers.py
@@ -97,12 +97,14 @@ def _use_local():
 @lru_cache
 def _version():
     if _use_local():
-        return importlib.metadata.version("napari")
+        version = importlib.metadata.version("napari")
+        if "+" in version:  # discard git hash and date
+            return version.split("+")[0]
     else:
         # get latest published on conda-forge
         r = requests.get(f"https://api.anaconda.org/package/conda-forge/napari")
         r.raise_for_status()
-        return r.json()["versions"][-1]
+        return r.json()["latest_version"]
 
 
 OUTPUT_FILENAME = f"{APP}-{_version()}-{OS}-{ARCH}.{EXT}"


### PR DESCRIPTION
Versions generated in linux have a date field now, in addition to the git hash. Examples:

- `napari-menu=0.4.16rc2.dev252+gf6bdd623.d20220827`
- `napari==0.4.16rc2.dev252+gf6bdd623.d20220827[build=*pyside*]`

Since all the triggers are coming from scheduled runs in `napari/napari` main, there's no risk to have a "number of commits since last tag" collision in parallel branches. That means we can safely discard everything after the `+` sign.