### PR TITLE
Constructor: Enable new `build_outputs` feature

### DIFF
--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -246,6 +246,7 @@ jobs:
 
     outputs:
       licenses-artifact: ${{ steps.licenses.outputs.licenses_artifact }}
+      pkgs-list-artifact: ${{ steps.pkgs-list.outputs.pkgs_list_artifact }}
 
     steps:
       - name: Checkout code
@@ -438,6 +439,22 @@ jobs:
         with:
           path: ${{ env.LICENSES_ARTIFACT_PATH }}
           name: ${{ env.LICENSES_ARTIFACT_NAME }}
+
+      - name: Collect list of packages
+        id: pkgs-list
+        shell: bash -el {0}
+        working-directory: napari-packaging
+        run: |
+          pkgs_list_zip_path=$(python build_installers.py --pkgs-list)
+          echo "PKGS_LIST_ARTIFACT_PATH=$pkgs_list_zip_path" >> $GITHUB_ENV
+          echo "PKGS_LIST_ARTIFACT_NAME=$(basename ${pkgs_list_zip_path})" >> $GITHUB_ENV
+          echo "pkgs_list_artifact=${pkgs_list_zip_path}" >> $GITHUB_OUTPUT
+
+      - name: Upload License Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ env.PKGS_LIST_ARTIFACT_PATH }}
+          name: ${{ env.PKGS_LIST_ARTIFACT_NAME }}
 
       - name: Notarize & staple PKG Installer (macOS)
         # We only sign pushes to main, nightlies, RCs and final releases

--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -423,21 +423,21 @@ jobs:
         working-directory: napari-packaging
         run: python build_installers.py --location=../napari-source
 
-      # - name: Collect licenses
-      #   id: licenses
-      #   shell: bash -el {0}
-      #   working-directory: napari-packaging
-      #   run: |
-      #     licenses_zip_path=$(python build_installers.py --licenses)
-      #     echo "LICENSES_ARTIFACT_PATH=$licenses_zip_path" >> $GITHUB_ENV
-      #     echo "LICENSES_ARTIFACT_NAME=$(basename ${licenses_zip_path})" >> $GITHUB_ENV
-      #     echo "licenses_artifact=${licenses_zip_path}" >> $GITHUB_OUTPUT
+      - name: Collect licenses
+        id: licenses
+        shell: bash -el {0}
+        working-directory: napari-packaging
+        run: |
+          licenses_zip_path=$(python build_installers.py --licenses)
+          echo "LICENSES_ARTIFACT_PATH=$licenses_zip_path" >> $GITHUB_ENV
+          echo "LICENSES_ARTIFACT_NAME=$(basename ${licenses_zip_path})" >> $GITHUB_ENV
+          echo "licenses_artifact=${licenses_zip_path}" >> $GITHUB_OUTPUT
 
-      # - name: Upload License Artifact
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     path: ${{ env.LICENSES_ARTIFACT_PATH }}
-      #     name: ${{ env.LICENSES_ARTIFACT_NAME }}
+      - name: Upload License Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ env.LICENSES_ARTIFACT_PATH }}
+          name: ${{ env.LICENSES_ARTIFACT_NAME }}
 
       - name: Notarize & staple PKG Installer (macOS)
         # We only sign pushes to main, nightlies, RCs and final releases

--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -450,7 +450,7 @@ jobs:
           echo "PKGS_LIST_ARTIFACT_NAME=$(basename ${pkgs_list_zip_path})" >> $GITHUB_ENV
           echo "pkgs_list_artifact=${pkgs_list_zip_path}" >> $GITHUB_OUTPUT
 
-      - name: Upload License Artifact
+      - name: Upload list of packages artifact
         uses: actions/upload-artifact@v3
         with:
           path: ${{ env.PKGS_LIST_ARTIFACT_PATH }}

--- a/build_installers.py
+++ b/build_installers.py
@@ -264,7 +264,7 @@ def _definitions(version=_version(), extra_specs=None, napari_repo=HERE):
         ],
         "build_outputs": [
             {"pkgs_list": {"env": napari_env["name"]}},
-            {"licenses": {"include_text": True}},
+            {"licenses": {"include_text": True, "text_errors": "replace"}},
         ]
     }
     if _use_local():
@@ -371,7 +371,7 @@ def _constructor(version=_version(), extra_specs=None, napari_repo=HERE):
         version=version, extra_specs=extra_specs, napari_repo=napari_repo
     )
 
-    args = [constructor, "-v", "--debug", "."]
+    args = [constructor, "-v", "."]
     conda_exe = os.environ.get("CONSTRUCTOR_CONDA_EXE")
     if TARGET_PLATFORM and conda_exe:
         args += ["--platform", TARGET_PLATFORM, "--conda-exe", conda_exe]

--- a/build_installers.py
+++ b/build_installers.py
@@ -412,6 +412,19 @@ def licenses():
     return zipname.resolve()
 
 
+def packages_list():
+    txtfile = next(Path("_work").glob("pkg-list.napari-*.txt"), None)
+    if not txtfile or not txtfile.is_file():
+        sys.exit(
+            "!! pkg-list.napari-*.txt not found."
+            "Ensure 'construct.yaml' has a 'build_outputs' key configured with 'pkgs_list'.",
+        )
+    zipname = Path("_work") / f"pkg-list.{OS}-{ARCH}.zip"
+    with zipfile.ZipFile(zipname, mode="w", compression=zipfile.ZIP_DEFLATED) as ozip:
+        ozip.write(txtfile)
+    return zipname.resolve()
+    
+
 def main(extra_specs=None, napari_repo=HERE):
     try:
         cwd = os.getcwd()
@@ -464,6 +477,12 @@ def cli(argv=None):
         "This must be run as a separate step.",
     )
     p.add_argument(
+        "--pkgs-list",
+        action="store_true",
+        help="Generate the list of packages used to build the napari environment."
+        "This must be run as a separate step.",
+    )
+    p.add_argument(
         "--images",
         action="store_true",
         help="Generate background images from the logo (test only)",
@@ -496,6 +515,9 @@ if __name__ == "__main__":
         sys.exit()
     if args.licenses:
         print(licenses())
+        sys.exit()
+    if args.pkgs_list:
+        print(packages_list())
         sys.exit()
     if args.images:
         _generate_background_images(napari_repo=args.location)

--- a/build_installers.py
+++ b/build_installers.py
@@ -265,7 +265,7 @@ def _definitions(version=_version(), extra_specs=None, napari_repo=HERE):
         "build_outputs": [
             {"pkgs_list": {"env": napari_env["name"]}},
             {"licenses": {"include_text": True, "text_errors": "replace"}},
-        ]
+        ],
     }
     if _use_local():
         definitions["channels"].insert(0, "local")
@@ -403,7 +403,8 @@ def licenses():
     if not info_path.is_file():
         sys.exit(
             "!! licenses.json not found."
-            "Ensure 'construct.yaml' has a 'build_outputs' key configured with 'licenses'.",
+            "Ensure 'construct.yaml' has a 'build_outputs' "
+            "key configured with 'licenses'.",
         )
 
     zipname = Path("_work") / f"licenses.{OS}-{ARCH}.zip"
@@ -417,13 +418,14 @@ def packages_list():
     if not txtfile or not txtfile.is_file():
         sys.exit(
             "!! pkg-list.napari-*.txt not found."
-            "Ensure 'construct.yaml' has a 'build_outputs' key configured with 'pkgs_list'.",
+            "Ensure 'construct.yaml' has a 'build_outputs' "
+            "key configured with 'pkgs_list'.",
         )
     zipname = Path("_work") / f"pkg-list.{OS}-{ARCH}.zip"
     with zipfile.ZipFile(zipname, mode="w", compression=zipfile.ZIP_DEFLATED) as ozip:
         ozip.write(txtfile)
     return zipname.resolve()
-    
+
 
 def main(extra_specs=None, napari_repo=HERE):
     try:

--- a/build_installers.py
+++ b/build_installers.py
@@ -262,6 +262,10 @@ def _definitions(version=_version(), extra_specs=None, napari_repo=HERE):
             {condarc: ".condarc"},
             {env_state: env_state_path},
         ],
+        "build_outputs": [
+            {"pkgs_list": [napari_env["name"]]},
+            "licenses",
+        ]
     }
     if _use_local():
         definitions["channels"].insert(0, "local")


### PR DESCRIPTION
This new feature we upstreamed allows us to obtain the licenses summary and the used packages for the napari-env in an easy way.

This will close #56 and also close #14.