### PR TITLE
Prepare new `constructor` stack release

### DIFF
--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -4,10 +4,10 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'build_installers.py'
-      - 'conda-recipe/*'
-      - '.github/workflows/make_bundle_conda.yml'  # this file
+    # paths:
+    #   - 'build_installers.py'
+    #   - 'conda-recipe/*'
+    #   - '.github/workflows/make_bundle_conda.yml'  # this file
   workflow_call:
     inputs:
       event_name:

--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -4,10 +4,10 @@ on:
   pull_request:
     branches:
       - main
-    # paths:
-    #   - 'build_installers.py'
-    #   - 'conda-recipe/*'
-    #   - '.github/workflows/make_bundle_conda.yml'  # this file
+    paths:
+      - 'build_installers.py'
+      - 'conda-recipe/*'
+      - '.github/workflows/make_bundle_conda.yml'  # this file
   workflow_call:
     inputs:
       event_name:

--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -80,7 +80,7 @@ jobs:
           path: napari-feedstock
 
       - name: install micromamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: napari-packaging/environments/ci_packages_environment.yml
 
@@ -265,11 +265,10 @@ jobs:
           ref: ${{ github.event_name != 'workflow_dispatch' && '' || github.event.inputs.ref }}
 
       - name: install micromamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: napari-packaging/environments/ci_installers_environment.yml
-          extra-specs: |
-            python=${{ matrix.python-version }}
+          create-args: python=${{ matrix.python-version }}
 
       - name: Conda info
         shell: bash -el {0}

--- a/build_installers.py
+++ b/build_installers.py
@@ -201,7 +201,7 @@ def _base_env(python_version=PY_VER):
     return {
         "name": "base",
         "channels": [
-            "napari/label/bundle_tools_2",
+            "napari/label/bundle_tools_3",
             "conda-forge",
         ],
         "specs": [

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -39,7 +39,7 @@ outputs:
         - python >=3.8
 
         # dependencies matched to setup.cfg
-        - app-model >=0.1.0,<0.3.0
+        - app-model >=0.1.2,<0.3.0
         - appdirs >=1.4.4
         - cachey >=0.2.1
         - certifi >=2020.6.20
@@ -50,7 +50,7 @@ outputs:
         - magicgui >=0.3.6
         - napari-console >=0.0.6
         - napari-plugin-engine >=0.1.9
-        - napari-svg >=0.1.6
+        - napari-svg >=0.1.7
         - npe2 >=0.5.2
         - numpy >=1.20
         - numpydoc >=0.9.2

--- a/environments/ci_installers_environment.yml
+++ b/environments/ci_installers_environment.yml
@@ -1,6 +1,6 @@
 name: build-bundle
 channels:
-  - napari/label/bundle_tools_2
+  - napari/label/bundle_tools_3
   - conda-forge
 dependencies:
   - python


### PR DESCRIPTION
I've been building a new set of packages to `napari/label/bundle_tools_3`. It's almost ready so let's start the attempts. First a commit with no changes to get a control CI run.