### PR TITLE
require appropriate permissions for release asset upload

### DIFF
--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -219,6 +219,8 @@ jobs:
             f.write(f"matrix={json.dumps(matrix)}\n")
 
   installers:
+    permissions:
+      contents: write
     name: Bundle ${{ matrix.target-platform }}
     runs-on: ${{ matrix.os }}
     needs: [packages, prepare_matrix]


### PR DESCRIPTION
Should fix `Resource not accessible by integration` in https://github.com/napari/napari/actions/runs/6590873573