### PR TITLE
Fix osx-64 `base64` usage and add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -339,8 +339,8 @@ jobs:
           KEYCHAIN_PATH="$RUNNER_TEMP/installer-signing.keychain-db"
 
           # import certificate and provisioning profile from secrets
-          echo -n "${{ secrets.APPLE_INSTALLER_CERTIFICATE_BASE64 }}" | base64 --decode --output $INSTALLER_CERTIFICATE_PATH
-          echo -n "${{ secrets.APPLE_APPLICATION_CERTIFICATE_BASE64 }}" | base64 --decode --output $APPLICATION_CERTIFICATE_PATH
+          echo -n "${{ secrets.APPLE_INSTALLER_CERTIFICATE_BASE64 }}" | /usr/bin/base64 --decode --output $INSTALLER_CERTIFICATE_PATH
+          echo -n "${{ secrets.APPLE_APPLICATION_CERTIFICATE_BASE64 }}" | /usr/bin/base64 --decode --output $APPLICATION_CERTIFICATE_PATH
 
           # create temporary keychain
           security create-keychain -p "${{ secrets.TEMP_KEYCHAIN_PASSWORD }}" $KEYCHAIN_PATH


### PR DESCRIPTION
Comes from https://github.com/napari/packaging/issues/145#issuecomment-2149475205

---

Nightlies have been [failing in osx-64](https://github.com/napari/napari/actions/runs/9375965599/job/25815227728) for weeks due to:

```
base64: invalid argument --output
Usage:	base64 [-hDd] [-b num] [-i in_file] [-o out_file]
  -h, --help     display this message
  -Dd, --decode   decodes input
  -b, --break    break encoded string into num character lines
  -i, --input    input file (default: "-" for stdin)
  -o, --output   output file (default: "-" for stdout)
```

I assume something in the conda env is clobbering the system `base64` with a different interface.