### PR TITLE
Skip constructor 3.8.0 due to PKG bug

### DIFF
--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -8,6 +8,8 @@ on:
       - 'build_installers.py'
       - 'conda-recipe/*'
       - '.github/workflows/make_bundle_conda.yml'  # this file
+      - 'environments/ci_installers_environment.yml'
+      - 'environments/ci_packages_environment.yml'
   workflow_call:
     inputs:
       event_name:

--- a/environments/ci_installers_environment.yml
+++ b/environments/ci_installers_environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python
   - pip
-  - constructor >=3.6.0
+  - constructor >=3.6.0,!=3.8.0
   - conda-build >=3.28
   - ruamel.yaml
   - conda-standalone >=23.11.0


### PR DESCRIPTION
Workaround for this [constructor bug](https://github.com/conda/constructor/pull/820) reported in https://github.com/napari/packaging/issues/165