### PR TITLE
Bump bundled Python to v3.11

### DIFF
--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -193,10 +193,14 @@ jobs:
     steps:
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - name: Prepare matrix
         id: set-matrix
         shell: python
+        # The Python versions chosen below will determine which
+        # Python versions the installers will bundle. The general
+        # principle is to follow the SPEC-0 recommendation:
+        # https://scientific-python.org/specs/spec-0000/
         run: |
           import os
           import json

--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -204,22 +204,22 @@ jobs:
           elements = [
             {
               "os": "ubuntu-latest",
-              "python-version": "3.10",
+              "python-version": "3.11",
               "target-platform": "linux-64",
             },
             {
               "os": "macos-13",
-              "python-version": "3.10",
+              "python-version": "3.11",
               "target-platform": "osx-64",
             },
             {
               "os": "macos-14",
-              "python-version": "3.10",
+              "python-version": "3.11",
               "target-platform": "osx-arm64",
             },
             {
               "os": "windows-latest",
-              "python-version": "3.10",
+              "python-version": "3.11",
               "target-platform": "win-64",
             },
           ]

--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -204,22 +204,22 @@ jobs:
           elements = [
             {
               "os": "ubuntu-latest",
-              "python-version": "3.9",
+              "python-version": "3.10",
               "target-platform": "linux-64",
             },
             {
               "os": "macos-13",
-              "python-version": "3.9",
+              "python-version": "3.10",
               "target-platform": "osx-64",
             },
             {
               "os": "macos-14",
-              "python-version": "3.9",
+              "python-version": "3.10",
               "target-platform": "osx-arm64",
             },
             {
               "os": "windows-latest",
-              "python-version": "3.9",
+              "python-version": "3.10",
               "target-platform": "win-64",
             },
           ]


### PR DESCRIPTION
Comes from https://github.com/napari/napari-plugin-manager/issues/108#issuecomment-2384322137

While we are at this, I'd like to formalize our policy for the bundled Python version, because we keep discussing this and the outcome is slightly different every time. I thought we wanted to use the oldest supported Python version for each release. As of today, 3.8 is still supported for one more month, 3.9 for one more year ([more details](https://endoflife.date/python)). If that's "too old", what's the policy? 

- [SPEC0](https://scientific-python.org/specs/spec-0000/): we would take 3.11, as 3.10 is now recommended to drop (as of today lol)
- [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html): that'd give us 3.10 now.
- [conda-forge pinnings](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/756dd4a926b4a8c009b8b2b3c170f7a4fb0ec5aa/recipe/conda_build_config.yaml#L779), which don't follow a particular schedule, but consider it more conservative than NEP 29. At 3.9 now.
- [Python's EOL schedule](https://endoflife.date/python): still at 3.8 for one more month, 3.9 for one more year.

This PR implements NEP29, but happy to adjust.
