### PR TITLE
Workaround for `.dev` vs `rc` version ordering in conda

### DIFF
--- a/build_installers.py
+++ b/build_installers.py
@@ -128,7 +128,9 @@ def _version():
             # and git hash;  so we discard the date
             pre, post = version.split("+", 1)
             version = f"{pre}+{post.split('.')[0]}"
-            return version
+        if ".dev" in version and "rc" not in version:
+            # workaround for https://github.com/conda/conda/issues/12568
+            version = version.replace(".dev", "dev")
         return version
     else:
         # get latest published on conda-forge


### PR DESCRIPTION
Closes https://github.com/napari/packaging/issues/194