### PR TITLE
Update for release 0.6.0

### DIFF
--- a/conda-recipe/README.md
+++ b/conda-recipe/README.md
@@ -1,17 +1,26 @@
-This folder is a patched copy of the conda-forge/napari-feedstock `recipe/` directory:
+This folder is a patched copy of the conda-forge/napari-feedstock `recipe/`
+directory:
 - The `source` section points to a local source, not a PyPI tarball.
-- The `outputs` section might be different too to accommodate changes happening during development
-  (e.g. new dependency was added.)
+- The `outputs` section might be different too to accommodate changes happening
+  during development (e.g. new dependency was added.)
 
-Use this link to see what happened in `napari/napari:pyproject.toml`, compared to last release:
+Use this link to see what happened in `napari/napari:pyproject.toml`, compared
+to last release:
 
     https://github.com/napari/napari/compare/v${VERSION_HERE}...main
 
 and look for `pyproject.toml` in the Files tab.
 
-The point of having a local copy is to be able to update it while developing the next release,
-without needing to publish the changes on conda-forge. On releases, the recipe contents here
-must be synced with conda-forge (mostly the `outputs` section).
+You can also check the changes locally using git. For example, to check the
+changes since v0.5.6, make sure you have the latest main branch then use the
+command:
 
-If changes occur on conda-forge (e.g. changes required by new infra), the contents of `recipe/`
-must be synced here!
+    git diff v0.5.6..HEAD pyproject.toml
+
+The point of having a local copy is to be able to update it while developing
+the next release, without needing to publish the changes on conda-forge. On
+releases, the recipe contents here must be synced with conda-forge (mostly the
+`outputs` section).
+
+If changes occur on conda-forge (e.g. changes required by new infra), the
+contents of `recipe/` must be synced here!

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,12 +24,12 @@ outputs:
 
     requirements:
       host:
-        - python >=3.9
+        - python >=3.10
         - pip
         - setuptools >=69
         - setuptools_scm >=8
       run:
-        - python >=3.9
+        - python >=3.10
 
         # dependencies matched to pyproject.toml
         - app-model >=0.3.0,<0.4.0a
@@ -48,34 +48,34 @@ outputs:
         - magicgui >=0.7.0
         - napari-console >=0.1.1
         - napari-plugin-engine >=0.1.9
-        - npe2 >=0.7.6
-        - numpy >=1.22.2
-        - numpydoc >=0.9.2
-        - pandas >=1.3.0
+        - npe2 >=0.7.8
+        - numpy >=1.24.2
+        - numpydoc >=1.0.0
+        - pandas >=1.3.3
         - pillow >=9.0
         - pint >=0.17
-        - psutil >=5.0
+        - psutil >=5.9.0
         - psygnal >=0.5.0
-        - pydantic >=1.9.0
+        - pydantic >=2.2.0
         - pygments >=2.6.0
-        - pyopengl >=3.1.0
+        - pyopengl >=3.1.5
         - pywin32  # this is Windows only, but the package is no-op on Unix
-        - pyyaml >=5.1
+        - pyyaml >=6.0
         - qtpy >=1.10.0
         - scikit-image >=0.19.1
-        - scipy >=1.5.4
+        - scipy >=1.10.1
         - superqt >=0.6.7
         - tifffile >=2022.4.8
-        - toolz >=0.10.0
+        - toolz >=0.11.0
         - tqdm >=4.56.0
-        - typing_extensions >=4.2.0
+        - typing_extensions >=4.6.1
         - vispy >=0.14.1,<0.15.0a0
-        - wrapt >=1.11.1
+        - wrapt >=1.13.3
 
       run_constrained:
-        - pyside2 >=5.13.2,!=5.15.0
+        - pyside2 >=5.15.1
         - pyside6 <6.5|>=6.7
-        - pyqt >=5.13.2,!=5.15.0,<6.0a0|>=6.5,!=6.6.1
+        - pyqt >=5.15.8,<6.0a0|>=6.5,!=6.6.1
 
     test:
       requires:


### PR DESCRIPTION
Here are the changes to pyproject.toml:

```diff
diff --git a/pyproject.toml b/pyproject.toml
index d88105cca..206f0223c 100644
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,10 @@ classifiers = [
     "Programming Language :: C",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Visualization",
     "Topic :: Scientific/Engineering :: Information Analysis",
@@ -34,7 +34,7 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "appdirs>=1.4.4",
     "app-model>=0.3.0,<0.4.0",
@@ -48,29 +48,29 @@ dependencies = [
     "napari-console>=0.1.1",
     "napari-plugin-engine>=0.1.9",
     "napari-svg>=0.1.8",
-    "npe2>=0.7.6",
-    "numpy>=1.22.2",
-    "numpydoc>=0.9.2",
-    "pandas>=1.3.0",
+    "npe2>=0.7.8",
+    "numpy>=1.24.2",
+    "numpydoc>=1.0.0",
+    "pandas>=1.3.3",
     "Pillow>=9.0",
     "pint>=0.17",
-    "psutil>=5.0",
+    "psutil>=5.9.0",
     "psygnal>=0.5.0",
-    "pydantic>=1.9.0",
+    "pydantic>=2.2.0",
     "pygments>=2.6.0",
-    "PyOpenGL>=3.1.0",
+    "PyOpenGL>=3.1.5",
     "pywin32 ; platform_system == 'Windows'",
-    "PyYAML>=5.1",
+    "PyYAML>=6.0",
     "qtpy>=2.3.1",
     "scikit-image[data]>=0.19.1",
-    "scipy>=1.5.4",
+    "scipy>=1.10.1",
     "superqt>=0.6.7",
     "tifffile>=2022.7.28",
-    "toolz>=0.10.0",
+    "toolz>=0.11.0",
     "tqdm>=4.56.0",
-    "typing_extensions>=4.2.0",
+    "typing_extensions>=4.6.1",
     "vispy>=0.14.1,<0.15",
-    "wrapt>=1.11.1",
+    "wrapt>=1.13.3",
 ]
 dynamic = [
     "version",
@@ -92,7 +92,7 @@ Documentation = "https://napari.org"
 
 [project.optional-dependencies]
 pyside2 = [
-    "PySide2>=5.13.2,!=5.15.0 ; python_version < '3.11' and platform_machine != 'arm64'",
+    "PySide2>=5.15.1 ; python_version < '3.11' and platform_machine != 'arm64'",
 ]
 pyside6_experimental = [
     "PySide6 < 6.5 ; python_version < '3.12'"
@@ -105,7 +105,8 @@ pyside = [
     "napari[pyside2]"
 ]
 pyqt5 = [
-    "PyQt5>=5.13.2,!=5.15.0",
+    "PyQt5>=5.15.8",
+    "pyqt5-qt5<=5.15.2; sys_platform == 'Windows'",  # 5.15.2 is latest to build on Windows, required for `uv add` compatability as of uv 0.6.9
 ]
 pyqt = [
     "napari[pyqt5]"
@@ -126,9 +127,10 @@ optional-numba = [
 optional = [
     "napari[optional-base,optional-numba]",
     "triangle",
-    "PartSegCore-compiled-backend>=0.15.8",
+    "PartSegCore-compiled-backend>=0.15.11",
 ]
 testing = [
+    "napari[gallery]",
     "babel>=2.9.0",
     "fsspec>=2023.10.0",
     "hypothesis>=6.8.0",
@@ -142,7 +144,7 @@ testing = [
     "pytest-qt>=4.3.1",
     "pytest-pretty>=1.1.0",
     "pytest>=8.1.0",
-    "tensorstore>=0.1.13",
+    "tensorstore>=0.1.32",
     "virtualenv>=20.17",
     "xarray>=0.16.2",
     "IPython>=7.25.0",
@@ -151,10 +153,46 @@ testing = [
     "napari[optional-base]",
 ]
 testing_extra = [
-    "torch>=1.7",
+    "torch>=1.10.2",
+]
+# needed for gallery examples
+gallery = [
+    "glasbey",
+    "zarr",
+    "dask[array,distributed]",
+    "matplotlib",
+    "pooch",
+    "nilearn",
+    "xarray",
+    "h5netcdf",
+]
+# needed to build docs
+docs = [
+    "napari[gallery]",
+    "sphinx<8",
+    "sphinx-autobuild",
+    "sphinx-tabs",
+    "sphinx-tags",
+    "sphinx-design",
+    "sphinx-external-toc",
+    "sphinx-favicon>=1.0",
+    "sphinx-copybutton",
+    "sphinx-gallery",
+    "sphinx_autodoc_typehints==1.12.0",
+    "sphinxcontrib-mermaid>=1.0.0",
+    "sphinxext-opengraph[social-cards]",
+    "myst-nb",
+    "napari-sphinx-theme>=0.3.0",
+    "matplotlib",
+    "lxml[html_clean]>5",
+    "imageio-ffmpeg",
+    "pydeps",
+    "seedir",
+    "pytest",
+    "linkify-it-py",
 ]
 release = [
-    "PyGithub>=1.44.1",
+    "PyGithub>=1.46",
     "twine>=3.1.1",
     "gitpython>=3.1.0",
     "requests-cache>=0.9.2",
@@ -165,6 +203,8 @@ dev = [
     "pre-commit>=2.9.0",
     "pydantic",
     "python-dotenv",
+    "tox",
+    "tox-min-req",
     "napari[testing]",
 ]
 build = [
@@ -202,6 +242,7 @@ napari_builtins = [
 
 [tool.setuptools_scm]
 write_to = "napari/_version.py"
+fallback_version = "0.6.0.nogit"
 
 [tool.check-manifest]
 ignore = [
@@ -296,6 +337,8 @@ ignore = [
     "B028", # need to be fixed
     "PYI015", # it produces bad looking files (@jni opinion)
     "W191", "Q000", "Q001", "Q002", "Q003", "ISC001", # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "UP007", # temporary disable migrtion form Union[X, Y] to X | Y
+    "TC006", # put types in quotes in typing.cast
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -303,8 +346,8 @@ ignore = [
 "**/_tests/*.py" = ["B011", "INP001", "TRY301", "B018", "RUF012"]
 "napari/utils/_testsupport.py" = ["B011"]
 "tools/validate_strings.py" = ["F401"]
-"tools/**" = ["INP001", "T20"]
-"examples/**" = ["ICN001", "INP001", "T20"]
+"tools/**" = ["INP001", "T20", "LOG015"]
+"examples/**" = ["ICN001", "INP001", "T20", "LOG015"]
 "**/vendored/**" = ["TID"]
 "napari/benchmarks/**" = ["RUF012", "TID252"]
 
```

- **Update recipe accounting for changes to pyproject.toml**
- **Update conda recipe README with local instructions**
