### PR TITLE
Pin pyopengl to 3.1.6

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -58,7 +58,7 @@ outputs:
         - psygnal >=0.5.0
         - pydantic >=2.2.0
         - pygments >=2.6.0
-        - pyopengl ==3.1.6    # see napari/napari issue 7671 
+        - pyopengl ==3.1.6    # see napari/napari issue 7671
         - pywin32  # this is Windows only, but the package is no-op on Unix
         - pyyaml >=6.0
         - qtpy >=1.10.0

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -58,7 +58,7 @@ outputs:
         - psygnal >=0.5.0
         - pydantic >=2.2.0
         - pygments >=2.6.0
-        - pyopengl ==3.1.6
+        - pyopengl ==3.1.6    # see napari/napari issue 7671 
         - pywin32  # this is Windows only, but the package is no-op on Unix
         - pyyaml >=6.0
         - qtpy >=1.10.0

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -58,7 +58,7 @@ outputs:
         - psygnal >=0.5.0
         - pydantic >=2.2.0
         - pygments >=2.6.0
-        - pyopengl >=3.1.5
+        - pyopengl ==3.1.6
         - pywin32  # this is Windows only, but the package is no-op on Unix
         - pyyaml >=6.0
         - qtpy >=1.10.0


### PR DESCRIPTION
To prevent problems reported in napari/napari#7671, this PR pins pyopengl to 3.1.6.

We will need to remember to remove the pin once the issue is resolved.

Further discussion in:

https://napari.zulipchat.com/#narrow/channel/212875-general/topic/Linux.20users!.20Help!.20Check.20pyopengl!/with/513615281