### PR TITLE
Update meta.yaml for icon location and alpha handling in the build script

### DIFF
--- a/build_installers.py
+++ b/build_installers.py
@@ -128,7 +128,12 @@ def _version():
             # and git hash;  so we discard the date
             pre, post = version.split("+", 1)
             version = f"{pre}+{post.split('.')[0]}"
-        if ".dev" in version and "rc" not in version and "a" not in version and "b" not in version:
+        if (
+            ".dev" in version
+            and "rc" not in version
+            and "a" not in version
+            and "b" not in version
+        ):
             # workaround for https://github.com/conda/conda/issues/12568
             version = version.replace(".dev", "dev")
         return version

--- a/build_installers.py
+++ b/build_installers.py
@@ -323,7 +323,7 @@ def _definitions(version=_version(), extra_specs=None, napari_repo=HERE):
                 "welcome_image": os.path.join(resources, "napari_164x314.png"),
                 "header_image": os.path.join(resources, "napari_150x57.png"),
                 "icon_image": os.path.join(
-                    napari_repo, "napari", "resources", "icon.ico"
+                    napari_repo, "src", "napari", "resources", "icon.ico"
                 ),
                 "register_python": False,
                 "register_python_default": False,

--- a/build_installers.py
+++ b/build_installers.py
@@ -128,7 +128,7 @@ def _version():
             # and git hash;  so we discard the date
             pre, post = version.split("+", 1)
             version = f"{pre}+{post.split('.')[0]}"
-        if ".dev" in version and "rc" not in version:
+        if ".dev" in version and "rc" not in version and "a" not in version:
             # workaround for https://github.com/conda/conda/issues/12568
             version = version.replace(".dev", "dev")
         return version

--- a/build_installers.py
+++ b/build_installers.py
@@ -128,7 +128,7 @@ def _version():
             # and git hash;  so we discard the date
             pre, post = version.split("+", 1)
             version = f"{pre}+{post.split('.')[0]}"
-        if ".dev" in version and "rc" not in version and "a" not in version:
+        if ".dev" in version and "rc" not in version and "a" not in version and "b" not in version:
             # workaround for https://github.com/conda/conda/issues/12568
             version = version.replace(".dev", "dev")
         return version

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -146,9 +146,9 @@ outputs:
       script:
         - mkdir -p "${PREFIX}/Menu"
         - sed "s/__PKG_VERSION__/{{ PKG_VERSION }}/" "{{ SRC_DIR }}/resources/conda_menu_config.json" > "{{ PREFIX }}/Menu/napari-menu.json"
-        - cp "{{ SRC_DIR }}/napari/resources/logo.png" "{{ PREFIX }}/Menu/napari.png"
-        - cp "{{ SRC_DIR }}/napari/resources/icon.icns" "{{ PREFIX }}/Menu/napari.icns"
-        - cp "{{ SRC_DIR }}/napari/resources/icon.ico" "{{ PREFIX }}/Menu/napari.ico"
+        - cp "{{ SRC_DIR }}/src/napari/resources/logo.png" "{{ PREFIX }}/Menu/napari.png"
+        - cp "{{ SRC_DIR }}/src/napari/resources/icon.icns" "{{ PREFIX }}/Menu/napari.icns"
+        - cp "{{ SRC_DIR }}/src/napari/resources/icon.ico" "{{ PREFIX }}/Menu/napari.ico"
     requirements:
       build:
         - sed     # [unix]


### PR DESCRIPTION
I think this fixes the failure seen:
https://github.com/napari/packaging/actions/runs/15852222418/job/44688375177?pr=248

note that we have two resources dirs. one in the root of the repo and one in src/napari

Also fix the path errors by handling alpha releases (remove the extra period).
Alternative to https://github.com/napari/packaging/pull/231

(beta, or other prereleases may need something similar in the future)
