### PR TITLE
Update PySide to >=6.7.1 instead of 6.7

### DIFF
--- a/conda-recipe/recipe.yaml
+++ b/conda-recipe/recipe.yaml
@@ -77,7 +77,7 @@ outputs:
         - wrapt >=1.13.3
       run_constraints:
         - pyside2 >=5.15.1
-        - pyside6 >=6.7
+        - pyside6 >=6.7.1
         - pyqt >=5.15.8,<6.0a0|>=6.5,!=6.6.1
     tests:
       - python:


### PR DESCRIPTION
Just in case Peter's suspicions about critical bugs ([1]) are founded.

For reference, a link to the 6.7.1 changelog is included ([2]).

**Update**: Linked by Peter below: 
- comment about 6.7.1 being the first passing version ([3])
- Relevant bugfix in qt.io ([4])

[1]: https://github.com/napari/packaging/issues/269\#issuecomment-3120654140
[2]: https://code.qt.io/cgit/pyside/pyside-setup.git/tree/doc/changelogs/changes-6.7.1
[3]: https://github.com/napari/napari/issues/5657#issuecomment-2132379789
[4]: https://bugreports.qt.io/browse/PYSIDE-2675