### PR TITLE
Bump psygnal for v0.6.5

### DIFF
--- a/conda-recipe/recipe.yaml
+++ b/conda-recipe/recipe.yaml
@@ -59,7 +59,7 @@ outputs:
         - pillow >=9.0
         - pint >=0.17
         - psutil >=5.9.0
-        - psygnal >=0.10.0
+        - psygnal >=0.14.2
         - pydantic >=2.2.0
         - pygments >=2.6.0
         - pyopengl >=3.1.5


### PR DESCRIPTION
See https://github.com/napari/napari/pull/8297.
