### PR TITLE
Pin Windows runners to windows-2022

### DIFF
--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -238,7 +238,7 @@ jobs:
               "target-platform": "osx-arm64",
             },
             {
-              "os": "windows-latest",
+              "os": "windows-2022",
               "python-version": "3.11",
               "target-platform": "win-64",
             },


### PR DESCRIPTION
Workaround for signing errors in 2025 runners:

```
FileNotFoundError: Could not find C:/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x86/signtool.exe. Verify that the file exists or is in PATH.
```