### PR TITLE
Bump and pin GHA runner images

### DIFF
--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -223,22 +223,22 @@ jobs:
 
           elements = [
             {
-              "os": "ubuntu-latest",
+              "os": "ubuntu-2024",
               "python-version": "3.11",
               "target-platform": "linux-64",
             },
             {
-              "os": "macos-13",
+              "os": "macos-15-intel",
               "python-version": "3.11",
               "target-platform": "osx-64",
             },
             {
-              "os": "macos-14",
+              "os": "macos-15",
               "python-version": "3.11",
               "target-platform": "osx-arm64",
             },
             {
-              "os": "windows-2022",
+              "os": "windows-2025",
               "python-version": "3.11",
               "target-platform": "win-64",
             },

--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -418,6 +418,13 @@ jobs:
             mv "${_codesign}" "${_codesign}.in_conda_env"
           fi
 
+      - name: Check signtool (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          test -f "C:/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x64/signtool.exe"
+          echo "CONSTRUCTOR_SIGNTOOL_PATH=C:/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x64/signtool.exe" >> $GITHUB_ENV
+
       - name: Load signing certificate (Windows)
         # We only sign pushes to main, nightlies, RCs and final releases
         if: >
@@ -433,7 +440,6 @@ jobs:
 
           echo "CONSTRUCTOR_SIGNING_CERTIFICATE=${{ runner.temp }}/certificate.pfx" >> $Env:GITHUB_ENV
           echo "CONSTRUCTOR_PFX_CERTIFICATE_PASSWORD=${{ secrets.APPLE_INSTALLER_CERTIFICATE_PASSWORD }}" >> $Env:GITHUB_ENV
-          echo "CONSTRUCTOR_SIGNTOOL_PATH=C:/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x86/signtool.exe" >> $Env:GITHUB_ENV
 
       # TODO: Consider a refactor here; maybe an org action we can reuse or at least a script
       - name: Make Bundle (Linux)


### PR DESCRIPTION
Also check if `signtool` exists to avoid signing breakages during releases.