### PR TITLE
Update dependencies for napari 0.7.0a0

### DIFF
--- a/conda-recipe/recipe.yaml
+++ b/conda-recipe/recipe.yaml
@@ -37,7 +37,7 @@ outputs:
         - python >=${{ python_min }}
 
         # dependencies matched to pyproject.toml
-        - app-model >=0.4.0,<0.5.0
+        - app-model >=0.4.0,<0.5.0a
         - appdirs >=1.4.4
         - cachey >=0.2.1
         - certifi >=2018.1.18
@@ -75,7 +75,7 @@ outputs:
         - toolz >=0.11.0
         - tqdm >=4.56.0
         - typing_extensions >=4.12
-        - vispy >=0.15.2,<0.16
+        - vispy >=0.15.2,<0.16.0a0
         - wrapt >=1.13.3
       run_constraints:
         - pyside2 >=5.15.1
@@ -135,7 +135,7 @@ outputs:
         - ffmpeg
         - fsspec
         - imagecodecs
-        - napari-plugin-manager >=0.1.3,<0.2.0
+        - napari-plugin-manager >=0.1.3,<0.2.0a0
         - numba >=0.57.1
         - obstore  # needed to open remote files by zarr
         - partsegcore-compiled-backend >=0.15.11


### PR DESCRIPTION
Updates the dependency pins to match the latest napari pyproject.toml. I asked Claude to do this, and manually double-checked each change against our pyproject.toml.