### PR TITLE
Update `napari-plugin-engine`, `npe2`, `superqt`, `pyqments`, `qtpy`, `pydantic` extras for 0.7.0

### DIFF
--- a/conda-recipe/recipe.yaml
+++ b/conda-recipe/recipe.yaml
@@ -64,6 +64,8 @@ outputs:
         - psygnal >=0.14.2
         - pydantic >=2.8.0
         - pygments >=2.13.0
+        - pydantic-extra-types
+        - pydantic-settings
         - pyopengl >=3.1.5
         - pywin32 >=302
         - pyyaml >=6.0


### PR DESCRIPTION
Closes #346 

I did not add/update `tifffile[codecs]` or `trackastra` as they are gallery dependencies.