### PR TITLE
Use Python 3.13 for bundle

### DIFF
--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -56,6 +56,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+# The Python version chosen below will determine which
+# Python version the installers will bundle. The general
+# principle is to follow the SPEC-0 recommendation:
+# https://scientific-python.org/specs/spec-0000/
+# a specific Python could be defined for a platform in the `prepare_matrix` job
+# but should only be used in exceptional cases
+env:
+  INSTALLER_PYTHON_VERSION: "3.13"
+
 jobs:
   packages:
     name: Create packages
@@ -238,14 +247,10 @@ jobs:
     steps:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.11"
+          python-version: ${{ env.INSTALLER_PYTHON_VERSION }}
       - name: Prepare matrix
         id: set-matrix
         shell: python
-        # The Python versions chosen below will determine which
-        # Python versions the installers will bundle. The general
-        # principle is to follow the SPEC-0 recommendation:
-        # https://scientific-python.org/specs/spec-0000/
         run: |
           import os
           import json
@@ -253,22 +258,22 @@ jobs:
           elements = [
             {
               "os": "ubuntu-24.04",
-              "python-version": "3.11",
+              "python-version": ${{ env.INSTALLER_PYTHON_VERSION }},
               "target-platform": "linux-64",
             },
             {
               "os": "macos-15-intel",
-              "python-version": "3.11",
+              "python-version": ${{ env.INSTALLER_PYTHON_VERSION }},
               "target-platform": "osx-64",
             },
             {
               "os": "macos-15",
-              "python-version": "3.11",
+              "python-version": ${{ env.INSTALLER_PYTHON_VERSION }},
               "target-platform": "osx-arm64",
             },
             {
               "os": "windows-2025",
-              "python-version": "3.11",
+              "python-version": ${{ env.INSTALLER_PYTHON_VERSION }},
               "target-platform": "win-64",
             },
           ]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cd napari-packaging
 conda env create -n napari-packaging-installers --file environments/ci_installers_environment.yml
 conda activate napari-packaging-installers
 pip install -e ../napari --no-deps
-CONSTRUCTOR_PYTHON_VERSION="3.11" python build_installers.py --location ../napari
+CONSTRUCTOR_PYTHON_VERSION="3.13" python build_installers.py --location ../napari
 # Installers will be generated under `_work/`.
 ```
 
@@ -88,7 +88,7 @@ The installers can now be built from the local packages with:
 
 ```bash
 conda activate napari-packaging-installers
-CONSTRUCTOR_USE_LOCAL=1 CONDA_BLD_PATH=_work/packages/ CONSTRUCTOR_PYTHON_VERSION="3.11" python build_installers.py --location ../napari
+CONSTRUCTOR_USE_LOCAL=1 CONDA_BLD_PATH=_work/packages/ CONSTRUCTOR_PYTHON_VERSION="3.13" python build_installers.py --location ../napari
 ```
 
 The artifacts will be available in `_work/`.

--- a/environments/ci_installers_environment.yml
+++ b/environments/ci_installers_environment.yml
@@ -4,7 +4,7 @@ name: build-bundle
 channels:
   - conda-forge
 dependencies:
-  - python 3.11.*
+  - python 3.13.*
   - pip
   - constructor >=3.11.0
   - conda-build >=3.28

--- a/environments/ci_packages_environment.yml
+++ b/environments/ci_packages_environment.yml
@@ -8,7 +8,7 @@ channels:
   - conda-forge
 dependencies:
   - conda-smithy >=3.37.0
-  - python 3.11.*
+  - python 3.13.*
   - pip
   - tomlkit
   - ruamel.yaml


### PR DESCRIPTION
# References and Relevant Issues

Closes #370

# Description

Bump Python used for the bundle from 3.11 to 3.13.

Also, I use a env var to specify a single source of Python truth for CI as a start towards simplifying an update.
I opted not to remove the custom python-version matrix for now, given its relevance for #36, but at least for the past 2 years everyone platform has used the same python.
