### PR TITLE
Safely block pyside6 6.11 for bundle

### DIFF
--- a/conda-recipe/recipe.yaml
+++ b/conda-recipe/recipe.yaml
@@ -80,8 +80,8 @@ outputs:
         - wrapt >=1.13.3
       run_constraints:
         - pyside2 >=5.15.1
-        - pyside6 >=6.7.1
-        - pyqt >=5.15.8,<6.0a0|>=6.5,!=6.6.1
+        - pyside6 >=6.7.1,<6.11
+        - pyqt >=5.15.8,<6.0a0|>=6.5,!=6.6.1,<6.11
     tests:
       - python:
           pip_check: true


### PR DESCRIPTION
napari/napari#9052
https://napari.zulipchat.com/#narrow/channel/215289-release/topic/0.2E7.2E1.20-.20pop.20out.20widget.20bug.20on.20Qt.206.2E11.2E1.20.28latest.29/near/602306408

This more conservatively also blocks 6.11.0 because 6.11.1 also fixes some dock widget bugs that we may yet to uncover.