### PR TITLE
Bump python version and minimum version of packages for bundle

### DIFF
--- a/conda-recipe/recipe.yaml
+++ b/conda-recipe/recipe.yaml
@@ -41,7 +41,6 @@ outputs:
 
         # dependencies matched to pyproject.toml
         - app-model >=0.5.0,<0.6.0a
-        - appdirs >=1.4.4
         - cachey >=0.2.1
         - certifi >=2018.1.18
         # Do not depend on base "dask" package since it pulls

--- a/conda-recipe/recipe.yaml
+++ b/conda-recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: napari
   version: "REPLACE_ME"
-  python_min: "3.10"
+  python_min: "3.11"
   build_number: 0
   sdist_path: /home/conda/feedstock_root/napari-source
   local_napari_source: /home/conda/feedstock_root/napari-source
@@ -41,6 +41,7 @@ outputs:
 
         # dependencies matched to pyproject.toml
         - app-model >=0.5.0,<0.6.0a
+        - appdirs >=1.4.4
         - cachey >=0.2.1
         - certifi >=2018.1.18
         # Do not depend on base "dask" package since it pulls
@@ -58,7 +59,7 @@ outputs:
         - napari-svg >=0.1.8
         - npe2 >=0.8.1
         - numpy >=1.24.2
-        - pandas >=1.3.3
+        - pandas >=1.5.0
         - pillow >=10.0
         - pint >=0.17
         - platformdirs >=4.3.0
@@ -72,15 +73,15 @@ outputs:
         - pywin32 >=302
         - pyyaml >=6.0
         - qtpy >=2.4.0
-        - scikit-image >=0.19.1
+        - scikit-image >=0.20.0
         - scipy >=1.14.0
         - superqt >=0.7.8
         - tifffile >=2022.7.28
-        - toolz >=0.11.0
+        - toolz >=0.12.1
         - tqdm >=4.56.0
         - typing_extensions >=4.12
         - vispy >=0.16.1,<0.17.0a0
-        - wrapt >=1.13.3
+        - wrapt >=1.14.1
       run_constraints:
         - pyside2 >=5.15.1
         - pyside6 >=6.7.1,<6.11
@@ -142,7 +143,7 @@ outputs:
         - napari-plugin-manager >=0.1.10,<0.2.0a0
         - numba >=0.57.1
         - partsegcore-compiled-backend >=0.15.11
-        - zarr >=2.12.0
+        - zarr >=3.0.8
 
         # bundle-only convenience deps beyond pyproject optional extras
         - ffmpeg

--- a/conda-recipe/recipe.yaml
+++ b/conda-recipe/recipe.yaml
@@ -119,7 +119,6 @@ outputs:
       license: BSD-3-Clause AND MIT
       license_file:
         - LICENSE
-        - src/napari/_vendor/darkdetect/LICENSE
         - src/napari/_vendor/qt_json_builder/LICENSE
       documentation: http://napari.org
       repository: https://github.com/napari/napari


### PR DESCRIPTION
As we drop python 3.10, build bundle crashes 