### PR TITLE
Block rerender of recipe

### DIFF
--- a/.github/workflows/make_bundle_conda.yml
+++ b/.github/workflows/make_bundle_conda.yml
@@ -180,7 +180,7 @@ jobs:
           git diff
           grep -e "sdist_path: /home/conda" recipe/recipe.yaml
 
-          conda-smithy rerender
+          # conda-smithy rerender
           git diff
           mv ${GITHUB_WORKSPACE}/napari-source .
           echo "DOCKER_IMAGE=$(shyaml -y get-value docker_image.0 < .ci_support/${conda_build_config}.yaml)" >> $GITHUB_ENV


### PR DESCRIPTION
We cannot rerender the recipe until the new release of conda-smithy containing https://github.com/conda-forge/conda-smithy/pull/2626